### PR TITLE
Implementing ability to trace already running containers

### DIFF
--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -120,7 +120,7 @@ func TestCollectorBasic(t *testing.T) {
 	}
 
 	// Start container
-	cm.ContainerStarted(containedID)
+	cm.ContainerStarted(containedID, false)
 
 	// Send execve event
 	eventSink.SendExecveEvent(&tracing.ExecveEvent{
@@ -244,7 +244,7 @@ func TestCollectorWithContainerProfileUpdates(t *testing.T) {
 	}
 
 	// Start container
-	cm.ContainerStarted(containedID)
+	cm.ContainerStarted(containedID, false)
 
 	// Send execve event
 	eventSink.SendExecveEvent(&tracing.ExecveEvent{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -86,6 +86,11 @@ func (c *Controller) handleApplicationProfile(obj interface{}) {
 		return
 	}
 
+	// If the application profile is marked as partial, do not propagate it
+	if applicationProfile.GetAnnotations()["kapprofiler.kubescape.io/partial"] == "true" {
+		return
+	}
+
 	// Get Object name from ApplicationProfile. Application profile name has the kind in as the the prefix like deployment-nginx
 	objectName := strings.Join(strings.Split(applicationProfile.ObjectMeta.Name, "-")[1:], "-")
 	//kind := strings.Split(applicationProfile.ObjectMeta.Name, "-")[0]

--- a/pkg/tracing/container.go
+++ b/pkg/tracing/container.go
@@ -1,0 +1,30 @@
+package tracing
+
+import (
+	"fmt"
+	"os"
+
+	runtimeclient "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/runtime-client"
+	containerutilsTypes "github.com/inspektor-gadget/inspektor-gadget/pkg/container-utils/types"
+	igtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func DetectContainerRuntime(hostMount string) (*containerutilsTypes.RuntimeConfig, error) {
+	runtimes := map[igtypes.RuntimeName]string{
+		igtypes.RuntimeNameDocker:     runtimeclient.DockerDefaultSocketPath,
+		igtypes.RuntimeNameCrio:       runtimeclient.CrioDefaultSocketPath,
+		igtypes.RuntimeNameContainerd: runtimeclient.ContainerdDefaultSocketPath,
+		igtypes.RuntimeNamePodman:     runtimeclient.PodmanDefaultSocketPath,
+	}
+	for runtimeName, socketPath := range runtimes {
+		// Check if the socket is available on the host mount
+		socketPath = hostMount + socketPath
+		if _, err := os.Stat(socketPath); err == nil {
+			return &containerutilsTypes.RuntimeConfig{
+				Name:       runtimeName,
+				SocketPath: socketPath,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no container runtime detected at the following paths: %v", runtimes)
+}

--- a/pkg/tracing/container_test.go
+++ b/pkg/tracing/container_test.go
@@ -1,0 +1,17 @@
+package tracing
+
+import (
+	"testing"
+
+	igtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+)
+
+func TestContainerRuntimeDetection(t *testing.T) {
+	runtime, err := DetectContainerRuntime("")
+	if err != nil {
+		t.Errorf("error detecting container runtime: %s\n", err)
+	}
+	if runtime.Name != igtypes.RuntimeNameDocker {
+		t.Errorf("expected runtime name %s, got %s\n", igtypes.RuntimeNameDocker, runtime.Name)
+	}
+}

--- a/pkg/tracing/events.go
+++ b/pkg/tracing/events.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	ContainerActivityEventStart = "start"
-	ContainerActivityEventStop  = "stop"
+	ContainerActivityEventStart    = "start"
+	ContainerActivityEventAttached = "attached"
+	ContainerActivityEventStop     = "stop"
 )
 
 type EventType int


### PR DESCRIPTION
* Using container runtime to detect running containers
* Generating new events in tracer for "attaching" to containers besides "starting"
* Generating "partial" application profiles