### PR TITLE
Preventing controller to recursively generate consolidated application profiles

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 
 	"github.com/kubescape/kapprofiler/pkg/collector"
@@ -64,6 +65,12 @@ func (c *Controller) StartController() {
 			c.handleApplicationProfile(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) { // Called when an ApplicationProfile is updated
+			old, _ := c.getApplicationProfileFromObj(oldObj)
+			new, _ := c.getApplicationProfileFromObj(newObj)
+			if reflect.DeepEqual(old.Spec, new.Spec) {
+				return
+			}
+
 			c.handleApplicationProfile(newObj)
 		},
 		DeleteFunc: func(obj interface{}) { // Called when an ApplicationProfile is deleted


### PR DESCRIPTION
Up until now controller was patching on every application profile update regardless if the patch is actually changing the object. We implemented a check to make sure that if the update is not real then no patch is sent (which generates another update event)