### PR TITLE
Reporting eBPF errors in event sink interface

### DIFF
--- a/pkg/eventsink/es.go
+++ b/pkg/eventsink/es.go
@@ -2,6 +2,7 @@ package eventsink
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/kubescape/kapprofiler/pkg/inmemorymapdb"
 	"github.com/kubescape/kapprofiler/pkg/tracing"
@@ -278,6 +279,11 @@ func (es *EventSink) SendNetworkEvent(event *tracing.NetworkEvent) {
 			}
 		}
 	}
+}
+
+func (es *EventSink) ReportError(eventType tracing.EventType, err error) {
+	// There is not a lot we can do here
+	log.Printf("Error reported for event type %d: %s", eventType, err)
 }
 
 func (es *EventSink) Close() error {

--- a/pkg/tracing/events.go
+++ b/pkg/tracing/events.go
@@ -111,4 +111,6 @@ type EventSink interface {
 	SendDnsEvent(event *DnsEvent)
 	// SendNetworkEvent sends a Network event to the sink
 	SendNetworkEvent(event *NetworkEvent)
+	// ReportError reports an error to the sink
+	ReportError(eventType EventType, err error)
 }

--- a/pkg/tracing/ig.go
+++ b/pkg/tracing/ig.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/cilium/ebpf"
@@ -206,6 +207,10 @@ func (t *Tracer) dnsEventCallback(event *tracerdnstype.Event) {
 		for _, eventSink := range t.eventSinks {
 			eventSink.SendDnsEvent(dnsEvent)
 		}
+	} else if event.Type == eventtypes.ERR {
+		for _, eventSink := range t.eventSinks {
+			eventSink.ReportError(DnsEventType, fmt.Errorf("dns ebpf error: %s", event.Message))
+		}
 	}
 }
 
@@ -236,6 +241,10 @@ func (t *Tracer) networkEventCallback(event *tracernetworktype.Event) {
 		for _, eventSink := range t.eventSinks {
 			eventSink.SendNetworkEvent(networkEvent)
 		}
+	} else if event.Type == eventtypes.ERR {
+		for _, eventSink := range t.eventSinks {
+			eventSink.ReportError(NetworkEventType, fmt.Errorf("network ebpf error: %s", event.Message))
+		}
 	}
 }
 
@@ -262,6 +271,10 @@ func (t *Tracer) capabilitiesEventCallback(event *tracercapabilitiestype.Event) 
 		}
 		for _, eventSink := range t.eventSinks {
 			eventSink.SendCapabilitiesEvent(capabilitiesEvent)
+		}
+	} else if event.Type == eventtypes.ERR {
+		for _, eventSink := range t.eventSinks {
+			eventSink.ReportError(CapabilitiesEventType, fmt.Errorf("capabilities ebpf error: %s", event.Message))
 		}
 	}
 }
@@ -292,6 +305,10 @@ func (t *Tracer) openEventCallback(event *traceropentype.Event) {
 		for _, eventSink := range t.eventSinks {
 			eventSink.SendOpenEvent(openEvent)
 		}
+	} else if event.Type == eventtypes.ERR {
+		for _, eventSink := range t.eventSinks {
+			eventSink.ReportError(OpenEventType, fmt.Errorf("open ebpf error: %s", event.Message))
+		}
 	}
 }
 
@@ -321,6 +338,10 @@ func (t *Tracer) execEventCallback(event *tracerexectype.Event) {
 		}
 		for _, eventSink := range t.eventSinks {
 			eventSink.SendExecveEvent(execveEvent)
+		}
+	} else if event.Type == eventtypes.ERR {
+		for _, eventSink := range t.eventSinks {
+			eventSink.ReportError(ExecveEventType, fmt.Errorf("execve ebpf error: %s", event.Message))
 		}
 	}
 }


### PR DESCRIPTION
Adding the capability to the tracer to report errors (dropped events etc) to the event sink interface